### PR TITLE
Add README with usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# CFG to CNF Converter
+
+This project provides a simple Streamlit interface for converting context-free grammars (CFG) into Chomsky Normal Form (CNF).
+
+## Installation
+
+Use pip to install the dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the Streamlit app:
+
+```bash
+streamlit run app.py
+```
+
+This will open a browser window where you can paste your CFG and view the CNF conversion steps.
+
+## Example CFG Format
+
+Enter productions one per line using `->` (or `→`) and separate alternatives with `|`.
+Epsilon (the empty string) can be written as `ε` or `E`.
+
+```
+S -> AB | a
+A -> aA | ε
+B -> b
+```
+
+After entering your grammar, click **Convert to CNF** to see the transformed grammar and the step-by-step process.
+


### PR DESCRIPTION
## Summary
- document project purpose in README
- show installation and startup commands
- include example CFG syntax for the converter

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py cnf_converter.py`

------
https://chatgpt.com/codex/tasks/task_e_6867396cdeec8331998397c67a024643