### PR TITLE
Add language generation to CFG app

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,10 @@ Separate productions with new lines. Use 'ε' for the empty string.
 
 grammar_input = st.text_area("Enter CFG:", height=200)
 
+# Controls for language generation
+max_length = st.slider("Max length of generated words", 1, 10, 4)
+max_words = st.slider("Max number of words", 1, 50, 10)
+
 if st.button("Convert to CNF"):
     from cnf_converter import cfg_to_cnf, parse_cfg
     try:
@@ -28,5 +32,19 @@ if st.button("Convert to CNF"):
             for title, g in steps:
                 st.markdown(f"**{title}:**")
                 st.code(g)
+    except Exception as e:
+        st.error(f"Error: {e}")
+
+if st.button("Generate Language"):
+    from cnf_converter import parse_cfg, generate_words
+    try:
+        cfg = parse_cfg(grammar_input)
+        words = generate_words(cfg, max_length=max_length, max_words=max_words)
+        st.subheader("Generated Language:")
+        table_data = [{"Word": w, "Symbols": " ".join(list(w))} for w in words]
+        if table_data:
+            st.table(table_data)
+        else:
+            st.info("No words generated with the given limits.")
     except Exception as e:
         st.error(f"Error: {e}")

--- a/cnf_converter.py
+++ b/cnf_converter.py
@@ -74,6 +74,58 @@ def cfg_to_cnf(grammar):
 
     return format_grammar(grammar), steps
 
+def generate_words(grammar, start=None, max_length=4, max_words=20):
+    """Generate words from the grammar up to a given length.
+
+    Parameters
+    ----------
+    grammar : dict
+        The CFG as produced by ``parse_cfg``.
+    start : str, optional
+        Start symbol. If ``None`` the first key of ``grammar`` is used.
+    max_length : int, default 4
+        Maximum length of words (in terminal symbols).
+    max_words : int, default 20
+        Maximum number of words to generate.
+
+    Returns
+    -------
+    list of str
+        Sorted list of generated words.
+    """
+    if start is None:
+        start = next(iter(grammar))
+
+    words = set()
+    from collections import deque
+
+    queue = deque()
+    queue.append([start])
+
+    while queue and len(words) < max_words:
+        current = queue.popleft()
+
+        # If current sequence is all terminals, consider it a word
+        if all(symbol not in grammar for symbol in current):
+            word = "".join(current)
+            if len(word) <= max_length:
+                words.add(word)
+            continue
+
+        # Prune sequences that already exceed max_length
+        if sum(1 for s in current if s not in grammar) > max_length:
+            continue
+
+        # Expand the first nonterminal in the sequence
+        for i, symbol in enumerate(current):
+            if symbol in grammar:
+                for prod in grammar[symbol]:
+                    new_seq = current[:i] + prod + current[i+1:]
+                    queue.append(new_seq)
+                break
+
+    return sorted(words)
+
 def remove_null_productions(grammar, start):
     # Find nullable nonterminals
     nullable = set()


### PR DESCRIPTION
## Summary
- implement `generate_words` in `cnf_converter.py`
- show generated language in `app.py`

## Testing
- `python -m py_compile app.py cnf_converter.py`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68677cbf1fd88331ad7153e2bdfbe3ad