### PR TITLE
Add unit tests for grammar tools

### DIFF
--- a/cnf_converter.py
+++ b/cnf_converter.py
@@ -258,3 +258,50 @@ def format_grammar(grammar):
         right = [" ".join(prod) for prod in prods]
         lines.append(f"{nt} -> {' | '.join(right)}")
     return "\n".join(lines)
+
+def generate_words(grammar, start=None, max_length=5):
+    """Generate all words from the CFG up to ``max_length`` terminals.
+
+    Parameters
+    ----------
+    grammar : dict
+        Grammar returned by :func:`parse_cfg`.
+    start : str, optional
+        Start symbol. Defaults to the first key in ``grammar``.
+    max_length : int
+        Maximum length (in terminals) of generated words.
+
+    Returns
+    -------
+    set[str]
+        Set of terminal words with length ``<= max_length``.
+    """
+    if start is None:
+        start = next(iter(grammar))
+
+    words = set()
+    queue = [[start]]
+
+    while queue:
+        seq = queue.pop(0)
+
+        # Current length ignoring nonterminals and epsilons
+        current_word = "".join(s for s in seq if s not in grammar and s != "ε")
+        if len(current_word) > max_length:
+            continue
+
+        # If sequence contains only terminals
+        if all(s not in grammar for s in seq):
+            words.add(current_word)
+            continue
+
+        # Expand the first nonterminal in the sequence
+        for i, sym in enumerate(seq):
+            if sym in grammar:
+                for prod in grammar[sym]:
+                    # Skip epsilon in the middle of sequences
+                    new_seq = seq[:i] + [t for t in prod if t != "ε"] + seq[i+1:]
+                    queue.append(new_seq)
+                break
+
+    return {w for w in words if len(w) <= max_length}

--- a/tests/test_cnf.py
+++ b/tests/test_cnf.py
@@ -1,0 +1,54 @@
+import unittest
+from cnf_converter import parse_cfg, cfg_to_cnf, generate_words
+
+class TestCNFConverter(unittest.TestCase):
+    def test_parse_cfg_basic(self):
+        cfg_str = "S -> AB | a\nA -> aA | ε\nB -> b"
+        expected = {
+            'S': [['A', 'B'], ['a']],
+            'A': [['a', 'A'], ['ε']],
+            'B': [['b']]
+        }
+        self.assertEqual(parse_cfg(cfg_str), expected)
+
+    def test_parse_cfg_arrows_and_epsilon(self):
+        cfg_str = "S → A\nA -> E"
+        expected = {
+            'S': [['A']],
+            'A': [['ε']]
+        }
+        self.assertEqual(parse_cfg(cfg_str), expected)
+
+    def test_cfg_to_cnf_steps_and_result(self):
+        cfg_str = "S -> AB | a\nA -> aA | ε\nB -> b"
+        grammar = parse_cfg(cfg_str)
+        cnf_str, steps = cfg_to_cnf(grammar)
+
+        expected_titles = [
+            'Original grammar',
+            'After removing ε-productions',
+            'After removing unit productions',
+            'After removing useless symbols',
+            'Chomsky Normal Form (CNF)'
+        ]
+        self.assertEqual([t for t, _ in steps], expected_titles)
+
+        expected_cnf = parse_cfg("S -> a | b | A B\nA -> a | T1 A\nB -> b\nT1 -> a")
+
+        def as_sets(g):
+            return {nt: {tuple(p) for p in prods} for nt, prods in g.items()}
+
+        self.assertEqual(as_sets(parse_cfg(cnf_str)), as_sets(expected_cnf))
+
+    def test_generate_words_simple(self):
+        grammar = parse_cfg("S -> aS | b")
+        words = generate_words(grammar, 'S', max_length=3)
+        self.assertEqual(words, {'b', 'ab', 'aab'})
+
+    def test_generate_words_with_epsilon(self):
+        grammar = parse_cfg("S -> ε | a")
+        words = generate_words(grammar, 'S', max_length=1)
+        self.assertEqual(words, {'', 'a'})
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `generate_words` helper for producing words from CFG
- add `tests` package with coverage for parsing, CNF conversion, and word generation

## Testing
- `python -m unittest discover -v`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867b3cdb6608331922748d9578585dd