### PR TITLE
Fix CNF conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,15 @@ B  → b
 
 ## 5  Final Chomsky Normal Form
 ```cfg
-AS → AS A | A S
-S0 → A AS | T1 B
-S  → A AS | T1 B
-X1 → X1 S | B I
-A  → B X1
+S0 → A X1 | T_a B | a
+A  → B X3 | T_I S
 B  → b
-T1 → a
+S  → A X2 | T_a B | a
+T_I → I
+T_a → a
+X1 → S A
+X2 → S A
+X3 → T_I S
 ```
-
-NEED TO CORECT (Empty String still there)
 
 

--- a/cnf_converter.py
+++ b/cnf_converter.py
@@ -1,260 +1,286 @@
-# cnf_converter.py
-"""
-Module to parse a context-free grammar and convert it to Chomsky Normal Form (CNF).
-"""
+"""Utilities to convert a context free grammar to strict Chomsky Normal Form."""
+
+from __future__ import annotations
+
 import re
 from collections import defaultdict
 
-def parse_cfg(cfg_str):
+
+########################
+# Parsing and printing #
+########################
+
+def parse_cfg(text: str) -> dict[str, list[list[str]]]:
+    """Parse a grammar from ``text``.
+
+    Each line must have the form ``A -> B C | a``. ``E`` is treated as ``ε``.
+    Terminals can be written without spaces, e.g. ``AB`` means ``A B`` when both
+    symbols are non-terminals.  The function returns ``{lhs: [[rhs], ...]}``.
     """
-    Parse a CFG from a string. Returns a dictionary: {nonterminal: [[symbols], ...], ...}
-    """
-    grammar = defaultdict(list)
-    # Accept both '->' and '→' as arrows, and allow multiple productions per line
-    arrow_pattern = re.compile(r'\s*(->|→)\s*')
-    for line in cfg_str.strip().splitlines():
+
+    grammar: dict[str, list[list[str]]] = defaultdict(list)
+    arrow = re.compile(r"\s*(->|→)\s*")
+    for line in text.strip().splitlines():
         line = line.strip()
         if not line:
             continue
-        # Split into left and right at the first arrow
-        m = arrow_pattern.split(line, maxsplit=1)
+        m = arrow.split(line, maxsplit=1)
         if len(m) < 3:
-            continue  # skip invalid lines
-        left = m[0].strip()
-        right = m[2].strip()
-        # Split right side by '|'
-        productions = [p.strip() for p in right.split('|')]
-        for prod in productions:
-            # Accept 'E' or 'ε' as epsilon (empty string)
-            prod = prod.replace('E', 'ε')
-            if prod == 'ε':
-                symbols = ['ε']
+            continue
+        lhs, rhs = m[0].strip(), m[2].strip()
+        for alt in rhs.split("|"):
+            alt = alt.strip().replace("E", "ε")
+            if alt == "ε":
+                grammar[lhs].append(["ε"])
             else:
-                # Split by whitespace, or treat as single symbols if no spaces
-                if ' ' in prod:
-                    symbols = prod.split()
+                if " " in alt:
+                    symbols = alt.split()
                 else:
-                    symbols = list(prod)
-            grammar[left].append(symbols)
+                    symbols = list(alt)
+                grammar[lhs].append(symbols)
     return dict(grammar)
 
-def cfg_to_cnf(grammar):
+
+def format_grammar(grammar: dict[str, list[list[str]]], start: str) -> str:
+    """Return a nicely formatted grammar sorted as required."""
+
+    lines = []
+    order = [start] + sorted(nt for nt in grammar if nt != start)
+    for nt in order:
+        prods = grammar.get(nt, [])
+        unique: list[list[str]] = []
+        for p in prods:
+            if p not in unique:
+                unique.append(p)
+        rhs = [" ".join(p) for p in unique]
+        if rhs:
+            lines.append(f"{nt} → {' | '.join(rhs)}")
+    return "\n".join(lines)
+
+
+#############################
+# CNF transformation steps   #
+#############################
+
+def cfg_to_cnf(grammar: dict[str, list[list[str]]]) -> tuple[str, list[tuple[str, str]]]:
+    """Convert ``grammar`` to strict CNF.
+
+    Returns ``(cnf_string, steps)`` where ``steps`` is a list of
+    ``(title, formatted_grammar)`` pairs describing each transformation stage.
     """
-    Convert a CFG (as a dict) to Chomsky Normal Form. Returns a string representation and step-by-step transformations.
-    """
-    steps = []
-    def add_step(title, g):
-        steps.append((title, format_grammar(g)))
 
-    # Step 0: Add new start symbol if start symbol appears on RHS
-    start = next(iter(grammar))
-    new_start = "S0"
-    if any(start in prod for prods in grammar.values() for prod in prods):
-        grammar = {**{new_start: [[start]]}, **grammar}
-        start = new_start
-        add_step("Add new start symbol", grammar)
-    else:
-        add_step("Original grammar", grammar)
+    steps: list[tuple[str, str]] = []
 
-    # Step 1: Remove null (epsilon) productions
-    grammar = remove_null_productions(grammar, start)
-    add_step("After removing ε-productions", grammar)
+    def add_step(title: str, g: dict[str, list[list[str]]]):
+        steps.append((title, format_grammar(g, start_symbol)))
 
-    # Step 2: Remove unit productions
-    grammar = remove_unit_productions(grammar)
-    add_step("After removing unit productions", grammar)
+    # 1. create new start symbol
+    original_start = next(iter(grammar))
+    start_symbol = "S0"
+    idx = 0
+    while start_symbol in grammar:
+        idx += 1
+        start_symbol = f"S{idx}"
+    grammar = {start_symbol: [[original_start]], **grammar}
+    add_step("Add a new start symbol", grammar)
 
-    # Step 3: Remove useless symbols
-    grammar = remove_useless_symbols(grammar, start)
-    add_step("After removing useless symbols", grammar)
+    # 2. remove epsilon-productions
+    grammar = remove_epsilons(grammar, start_symbol)
+    add_step("Remove ε-productions", grammar)
 
-    # Step 4: Convert to CNF
-    grammar = convert_to_cnf(grammar, start)
-    add_step("Chomsky Normal Form (CNF)", grammar)
+    # 3. remove unit productions
+    grammar = remove_units(grammar)
+    add_step("Remove unit productions", grammar)
 
-    return format_grammar(grammar), steps
+    # 4. remove useless symbols
+    grammar = remove_useless(grammar, start_symbol)
+    add_step("Remove useless symbols", grammar)
 
-def remove_null_productions(grammar, start):
-    # Find nullable nonterminals
-    nullable = set()
-    for nt, prods in grammar.items():
-        for prod in prods:
-            if prod == ['ε']:
-                nullable.add(nt)
+    # 5. replace terminals in long rules
+    grammar = replace_terminals(grammar)
+    add_step("Replace terminals in long rules", grammar)
+
+    # 6. binarize productions
+    grammar = binarize(grammar)
+    add_step("Binarize long rules", grammar)
+
+    # final formatted grammar
+    cnf = format_grammar(grammar, start_symbol)
+    steps.append(("Chomsky Normal Form", cnf))
+    return cnf, steps
+
+
+def remove_epsilons(grammar: dict[str, list[list[str]]], start: str) -> dict[str, list[list[str]]]:
+    """Eliminate ε-productions."""
+
+    nullable: set[str] = set()
+
     changed = True
     while changed:
         changed = False
         for nt, prods in grammar.items():
+            if nt in nullable:
+                continue
             for prod in prods:
-                if all(symbol in nullable for symbol in prod):
-                    if nt not in nullable:
-                        nullable.add(nt)
-                        changed = True
-    # Remove epsilon productions and add all possible combinations for nullable
-    new_grammar = defaultdict(list)
+                if prod == ["ε"] or all(sym in nullable for sym in prod):
+                    nullable.add(nt)
+                    changed = True
+                    break
+
+    new_grammar: dict[str, list[list[str]]] = defaultdict(list)
     for nt, prods in grammar.items():
         for prod in prods:
-            if prod == ['ε']:
+            if prod == ["ε"]:
                 continue
-            # Generate all combinations by including/excluding nullable symbols
-            positions = [i for i, s in enumerate(prod) if s in nullable]
-            total = 1 << len(positions)
-            for mask in range(total):
-                new_prod = []
-                for i, symbol in enumerate(prod):
-                    if i in positions:
-                        # If the bit is set, skip this symbol (remove it)
-                        if (mask >> positions.index(i)) & 1:
-                            continue
-                    new_prod.append(symbol)
+            positions = [i for i, sym in enumerate(prod) if sym in nullable]
+            subsets = 1 << len(positions)
+            for mask in range(subsets):
+                new_prod: list[str] = []
+                for i, sym in enumerate(prod):
+                    if i in positions and (mask >> positions.index(i)) & 1:
+                        continue
+                    new_prod.append(sym)
                 if not new_prod:
                     if nt == start:
-                        new_prod = ['ε']
+                        new_prod = ["ε"]
                     else:
                         continue
                 if new_prod not in new_grammar[nt]:
                     new_grammar[nt].append(new_prod)
     return dict(new_grammar)
 
-def remove_unit_productions(grammar):
-    new_grammar = defaultdict(list)
+
+def remove_units(grammar: dict[str, list[list[str]]]) -> dict[str, list[list[str]]]:
+    """Eliminate unit productions."""
+
+    new_grammar: dict[str, list[list[str]]] = defaultdict(list)
     for nt in grammar:
-        # BFS to find all non-unit productions reachable from nt
         queue = [nt]
-        visited = set()
+        visited: set[str] = set()
         while queue:
             current = queue.pop(0)
             for prod in grammar.get(current, []):
                 if len(prod) == 1 and prod[0] in grammar:
                     if prod[0] not in visited:
-                        queue.append(prod[0])
                         visited.add(prod[0])
+                        queue.append(prod[0])
                 else:
                     if prod not in new_grammar[nt]:
                         new_grammar[nt].append(prod)
     return dict(new_grammar)
 
-def remove_useless_symbols(grammar, start):
-    # Step 1: Remove non-generating symbols
-    generating = set()
-    for nt, prods in grammar.items():
-        for prod in prods:
-            if all(s not in grammar for s in prod):
-                generating.add(nt)
+
+def remove_useless(grammar: dict[str, list[list[str]]], start: str) -> dict[str, list[list[str]]]:
+    """Remove non-generating and unreachable symbols."""
+
+    generating: set[str] = set()
     changed = True
     while changed:
         changed = False
         for nt, prods in grammar.items():
+            if nt in generating:
+                continue
             for prod in prods:
-                if all(s in generating or s not in grammar for s in prod):
-                    if nt not in generating:
-                        generating.add(nt)
-                        changed = True
-    grammar = {nt: [prod for prod in prods if all(s in generating or s not in grammar for s in prod)]
-               for nt, prods in grammar.items() if nt in generating}
-    # Step 2: Remove unreachable symbols
-    reachable = set()
+                if all(sym not in grammar or sym in generating for sym in prod if sym != "ε"):
+                    generating.add(nt)
+                    changed = True
+                    break
+
+    grammar = {
+        nt: [p for p in prods if all(sym not in grammar or sym in generating for sym in p if sym != "ε")]
+        for nt, prods in grammar.items()
+        if nt in generating
+    }
+
+    reachable: set[str] = set()
     queue = [start]
     while queue:
         nt = queue.pop(0)
         if nt not in reachable:
             reachable.add(nt)
             for prod in grammar.get(nt, []):
-                for s in prod:
-                    if s in grammar and s not in reachable:
-                        queue.append(s)
+                for sym in prod:
+                    if sym in grammar and sym not in reachable:
+                        queue.append(sym)
+
     grammar = {nt: prods for nt, prods in grammar.items() if nt in reachable}
     return grammar
 
-def convert_to_cnf(grammar, start):
-    # Step 1: Replace terminals in productions of length > 1 with new nonterminals
-    new_grammar = defaultdict(list)
-    term_map = {}
-    term_counter = 1
+
+def replace_terminals(grammar: dict[str, list[list[str]]]) -> dict[str, list[list[str]]]:
+    """Introduce variables for terminals appearing in long productions."""
+
+    counter = 1
+    mapping: dict[str, str] = {}
+    new_grammar: dict[str, list[list[str]]] = defaultdict(list)
+
     for nt, prods in grammar.items():
         for prod in prods:
             if len(prod) > 1:
-                new_prod = []
-                for symbol in prod:
-                    # A terminal is a single lowercase letter or nonterminal is uppercase
-                    if len(symbol) == 1 and symbol.islower():
-                        if symbol not in term_map:
-                            new_nt = f"T{term_counter}"
-                            term_counter += 1
-                            term_map[symbol] = new_nt
-                        new_prod.append(term_map[symbol])
-                    else:
-                        new_prod.append(symbol)
+                new_prod: list[str] = []
+                for sym in prod:
+                    if sym in grammar:
+                        new_prod.append(sym)
+                    elif sym == "ε":
+                        new_prod.append(sym)
+                    else:  # terminal
+                        if sym not in mapping:
+                            name = f"T_{sym}"
+                            while name in grammar or name in mapping.values():
+                                counter += 1
+                                name = f"T_{sym}{counter}"
+                            mapping[sym] = name
+                        new_prod.append(mapping[sym])
                 new_grammar[nt].append(new_prod)
             else:
                 new_grammar[nt].append(prod)
-    # Add productions for the new terminal nonterminals
-    for t, nt_for_t in term_map.items():
-        new_grammar[nt_for_t].append([t])
 
-    # Step 2: Break up productions longer than 2, reusing variables for the same right-hand side
-    final_grammar = defaultdict(set)
-    # Book-style mapping for common pairs
-    book_pair_map = {
-        ("S", "A"): "A1",
-        ("U", "B"): "UB",
-        ("A", "A1"): "AA1",
-        ("A", "S"): "AS",
-        ("S", "A1"): "SA1",
-        ("S", "A"): "SA",
-        ("A", "S"): "AS",
-        ("T1", "B"): "T1B",
-        ("A", "S"): "AS",
-        ("A", "A"): "AA",
-    }
-    pair_map = {}  # maps tuple of symbols to variable name
-    var_counter = 1
-    def get_var_for_pair(pair):
-        # Use book-style mapping if available
-        if pair in book_pair_map:
-            name = book_pair_map[pair]
-            if name not in final_grammar:
-                final_grammar[name].add(tuple(pair))
-            return name
-        if pair in pair_map:
-            return pair_map[pair]
-        nonlocal var_counter
-        new_nt = f"X{var_counter}"
-        var_counter += 1
-        pair_map[pair] = new_nt
-        final_grammar[new_nt].add(tuple(pair))
-        return new_nt
+    for term, var in mapping.items():
+        new_grammar[var].append([term])
 
-    for nt, prods in new_grammar.items():
-        for prod in prods:
-            current = prod
-            prev_nt = nt
-            while len(current) > 2:
-                pair = (current[0], current[1])
-                new_nt = get_var_for_pair(pair)
-                final_grammar[prev_nt].add((current[0], new_nt))
-                current = [new_nt] + current[2:]
-                prev_nt = new_nt
-            final_grammar[prev_nt].add(tuple(current))
-    # Remove any productions that are not strictly CNF (A -> BC or A -> a)
-    cleaned_grammar = defaultdict(list)
-    for nt, prods in final_grammar.items():
-        for prod in prods:
-            if len(prod) == 1:
-                # Only allow ε for the start symbol
-                if prod == ['ε']:
-                    if nt == start:
-                        cleaned_grammar[nt].append(prod)
-                    # else: skip ε for non-start symbols
-                else:
-                    cleaned_grammar[nt].append(prod)
-            elif len(prod) == 2 and all(s.isupper() for s in prod):
-                cleaned_grammar[nt].append(prod)
-    return dict(cleaned_grammar)
+    return dict(new_grammar)
 
-def format_grammar(grammar):
-    lines = []
+
+def binarize(grammar: dict[str, list[list[str]]]) -> dict[str, list[list[str]]]:
+    """Binarize productions longer than 2."""
+
+    counter = 1
+
+    def fresh() -> str:
+        nonlocal counter
+        name = f"X{counter}"
+        counter += 1
+        while name in grammar:
+            name = f"X{counter}"
+            counter += 1
+        return name
+
+    new_grammar: dict[str, list[list[str]]] = defaultdict(list)
+
     for nt, prods in grammar.items():
-        right = [" ".join(prod) for prod in prods]
-        lines.append(f"{nt} -> {' | '.join(right)}")
-    return "\n".join(lines)
+        for prod in prods:
+            if len(prod) <= 2:
+                new_grammar[nt].append(prod)
+                continue
+
+            symbols = prod
+            prev = nt
+            while len(symbols) > 2:
+                y = fresh()
+                new_grammar[prev].append([symbols[0], y])
+                symbols = symbols[1:]
+                prev = y
+            new_grammar[prev].append(symbols)
+
+    return dict(new_grammar)
+
+
+if __name__ == "__main__":  # simple manual test
+    example = """S -> ASA | aB\nA -> BIS\nB -> b | ε"""
+    g = parse_cfg(example)
+    cnf, steps = cfg_to_cnf(g)
+    for title, text in steps:
+        print("---", title)
+        print(text)
+    print("\nCNF:\n", cnf)
+


### PR DESCRIPTION
## Summary
- rewrite CNF conversion to strictly follow the standard algorithm
- simplify final README example output

## Testing
- `python cnf_converter.py`
- `python - <<'PY'
from cnf_converter import parse_cfg, cfg_to_cnf
cfg_str='S -> ASA | aB\nA -> BIS\nB -> b | ε'
cnf,_=cfg_to_cnf(parse_cfg(cfg_str))
print(cnf)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6868b2b252c48331926b4d8a8bd2677f