### PR TITLE
Fix CNF algorithm and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,13 @@ B  → b
 
 ## 5  Final Chomsky Normal Form
 ```cfg
-AS → AS A | A S
-S0 → A AS | T1 B
-S  → A AS | T1 B
-X1 → X1 S | B I
-A  → B X1
+SA → S A
+S0 → A SA | T1 B | a
+S  → A SA | T1 B | a
+X1 → I S
+A  → I S | B X1
 B  → b
 T1 → a
 ```
-
-NEED TO CORECT (Empty String still there)
 
 

--- a/cnf_converter.py
+++ b/cnf_converter.py
@@ -209,11 +209,12 @@ def convert_to_cnf(grammar, start):
     }
     pair_map = {}  # maps tuple of symbols to variable name
     var_counter = 1
+
     def get_var_for_pair(pair):
         # Use book-style mapping if available
         if pair in book_pair_map:
             name = book_pair_map[pair]
-            if name not in final_grammar:
+            if tuple(pair) not in final_grammar[name]:
                 final_grammar[name].add(tuple(pair))
             return name
         if pair in pair_map:
@@ -227,15 +228,11 @@ def convert_to_cnf(grammar, start):
 
     for nt, prods in new_grammar.items():
         for prod in prods:
-            current = prod
-            prev_nt = nt
-            while len(current) > 2:
-                pair = (current[0], current[1])
+            while len(prod) > 2:
+                pair = (prod[-2], prod[-1])
                 new_nt = get_var_for_pair(pair)
-                final_grammar[prev_nt].add((current[0], new_nt))
-                current = [new_nt] + current[2:]
-                prev_nt = new_nt
-            final_grammar[prev_nt].add(tuple(current))
+                prod = prod[:-2] + [new_nt]
+            final_grammar[nt].add(tuple(prod))
     # Remove any productions that are not strictly CNF (A -> BC or A -> a)
     cleaned_grammar = defaultdict(list)
     for nt, prods in final_grammar.items():


### PR DESCRIPTION
## Summary
- correct CNF conversion logic so multi-symbol productions are split properly
- update README example for final CNF output

## Testing
- `python -m py_compile cnf_converter.py app.py`
- `python - <<'PY'
from cnf_converter import cfg_to_cnf, parse_cfg
cfg_str = """S -> A S A | a B
A -> B I S
B -> b | ε"""
print(cfg_to_cnf(parse_cfg(cfg_str))[0])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6868bd7af83483319ccce102ac21c136