### PR TITLE
Replace mistaken capital I with pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Selecting the "Show Steps tab will list all the conversion steps as show below:
 ```cfg
 S0 → S
 S  → A S A | a B
-A  → B I S
+A  → B | S
 B  → b | ε
 ```
 
@@ -52,7 +52,7 @@ B  → b | ε
 ```cfg
 S0 → S
 S  → A S A | a B
-A  → B I S
+A  → B | S
 B  → b
 ```
 
@@ -62,7 +62,7 @@ B  → b
 ```cfg
 S0 → A S A | a B
 S  → A S A | a B
-A  → B I S
+A  → B | S
 B  → b
 ```
 
@@ -72,7 +72,7 @@ B  → b
 ```cfg
 S0 → A S A | a B
 S  → A S A | a B
-A  → B I S
+A  → B | S
 B  → b
 ```
 
@@ -83,7 +83,7 @@ B  → b
 AS → AS A | A S
 S0 → A AS | T1 B
 S  → A AS | T1 B
-X1 → X1 S | B I
+X1 → X1 S | B |
 A  → B X1
 B  → b
 T1 → a


### PR DESCRIPTION
## Summary
- fix CFG examples in README by replacing `I` with `|`

## Testing
- `python -m py_compile app.py cnf_converter.py`
- `python app.py` *(fails to run fully in bare mode but shows startup warning)*
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_686ab5e493188331ab9337cf69b11fb6