### PR TITLE
Fix epsilon removal bug

### DIFF
--- a/cnf_converter.py
+++ b/cnf_converter.py
@@ -58,6 +58,10 @@ def cfg_to_cnf(grammar):
 
     # Step 1: Remove null (epsilon) productions
     grammar = remove_null_productions(grammar, start)
+    # Defensive sweep to ensure no stray ε remain
+    for A in list(grammar):
+        if A != start and ['ε'] in grammar[A]:
+            grammar[A] = [p for p in grammar[A] if p != ['ε']]
     add_step("After removing ε-productions", grammar)
 
     # Step 2: Remove unit productions
@@ -158,11 +162,11 @@ def remove_null_productions(grammar, start):
                         if (mask >> positions.index(i)) & 1:
                             continue
                     new_prod.append(symbol)
+                # keep ε only for the start symbol
                 if not new_prod:
-                    if nt == start:
-                        new_prod = ['ε']
-                    else:
-                        continue
+                    if nt == start and ['ε'] not in new_grammar[nt]:
+                        new_grammar[nt].append(['ε'])
+                    continue
                 if new_prod not in new_grammar[nt]:
                     new_grammar[nt].append(new_prod)
     return dict(new_grammar)

--- a/tests/test_cnf.py
+++ b/tests/test_cnf.py
@@ -62,5 +62,28 @@ class TestCNFConverter(unittest.TestCase):
         words = generate_words(grammar, 'S', max_length=1)
         self.assertEqual(words, {'', 'a'})
 
+    def test_epsilon_removal_correctness(self):
+        cfg_str = "A -> B A B | B | ε\nB -> 0 0 | ε"
+        grammar = parse_cfg(cfg_str)
+        cnf_str, steps = cfg_to_cnf(grammar)
+
+        epsilon_removed = None
+        for title, g in steps:
+            if title == 'After removing ε-productions':
+                epsilon_removed = parse_cfg(g)
+                break
+
+        # no ε-productions should remain except possibly for the new start symbol
+        for nt, prods in epsilon_removed.items():
+            if nt == 'S0':
+                continue
+            self.assertNotIn(['ε'], prods)
+
+        cnf = parse_cfg(cnf_str)
+        for nt, prods in cnf.items():
+            for p in prods:
+                if p == ['ε']:
+                    self.assertEqual(nt, 'S0')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure epsilon alternatives are only kept for the start symbol when eliminating null productions
- remove stray epsilon rules after epsilon removal
- test that epsilon rules only remain for the new start symbol

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b9185759c8331aaed80cc0d08fa2a